### PR TITLE
Should provide a slightly cleaner looking logo

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -22,8 +22,15 @@
   .logobox {
     font-size: 24px;
     border:10px solid black;
-    padding: 2rem 1rem;
     min-height: 3em;
+    display: flex;
+    padding: 0;
+    justify-content: center;
+    align-items: center;
     resize: both;
     border-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='100' height='100' viewBox='0 0 100 100' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Cstyle%3Epath%7Banimation:stroke 15s infinite linear%3B%7D%40keyframes stroke%7Bto%7Bstroke-dashoffset:776%3B%7D%7D%3C/style%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%232d3561' /%3E%3Cstop offset='25%25' stop-color='%23c05c7e' /%3E%3Cstop offset='50%25' stop-color='%23f3826f' /%3E%3Cstop offset='100%25' stop-color='%237253ED' /%3E%3C/linearGradient%3E %3Cpath d='M1.5 1.5 l97 0l0 97l-97 0 l0 -97' stroke-linecap='square' stroke='url(%23g)' stroke-width='3' stroke-dasharray='388'/%3E %3C/svg%3E") 1;
+    .site-title {
+        align-content: center;
+        justify-content: center;
+    }
   }


### PR DESCRIPTION
I didn't like how the link for the logo was stretched wide and super short, it made it so if you moused over the box in the center of the site title's border it wouldn't always pick up the mouse. This should make it so the link takes up the whole box, it does also make the link itself shorter but only to the size of the image inside.